### PR TITLE
make zign transparent

### DIFF
--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 import click
 
@@ -50,8 +51,9 @@ def cli(ctx):
 
 
 def get_token():
+    user = os.getenv('USER')
     try:
-        token = get_named_token(['uid'], None, 'fullstop', None, None)
+        token = get_named_token(['uid'], None, 'fullstop', user, None)
     except:
         raise click.UsageError('No valid OAuth token named "fullstop" found. Please use "zign token -n fullstop".')
     return token

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,6 @@ class PyTest(TestCommand):
         params = {'args': self.test_args}
         if self.cov:
             params['args'] += self.cov
-            params['plugins'] = ['cov']
         if self.junitxml:
             params['args'] += self.junitxml
         params['args'] += ['--doctest-modules', MAIN_PACKAGE, '-s']


### PR DESCRIPTION
Why is additional start form 'zign token' necessary?

i think, this is a bad usability....
