### PR TITLE
Possibility to filter violations by regular expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 virtualenv
 *.sw*
 .cache/
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,8 @@
 [flake8]
 max-line-length=120
+
+[tox]
+envlist=py34,py35
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
Currently is possible to filter violations by `key=value`, but for old violations the format of meta may not make possible to filter. So I have added the possibility to filter violations using regular expression over the meta field.
