### PR TITLE
Fixed handling of --all flag in list-violations.

### DIFF
--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -227,7 +227,7 @@ def list_violations(config, output, since, region, meta, remeta, limit, all, **k
     r.raise_for_status()
     data = r.json()['content']
 
-    if (all is True):
+    if (all):
         params['checked'] = 'true'
         r = request(url, '/api/violations', token, params=params)
         r.raise_for_status()
@@ -236,8 +236,6 @@ def list_violations(config, output, since, region, meta, remeta, limit, all, **k
     rows = []
     for row in data:
         if region and row['region'] != region:
-            continue
-        if row['comment'] and not all:
             continue
         if meta and not meta_matches(row['meta_info'], meta):
             continue

--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -222,12 +222,19 @@ def list_violations(config, output, since, region, meta, remeta, limit, all, **k
     params = {'size': limit, 'sort': 'id,DESC'}
     params['from'] = parse_since(since)
     params.update(kwargs)
+
     r = request(url, '/api/violations', token, params=params)
     r.raise_for_status()
-    data = r.json()
+    data = r.json()['content']
+
+    if (all is True):
+        params['checked'] = 'true'
+        r = request(url, '/api/violations', token, params=params)
+        r.raise_for_status()
+        data.extend(r.json()['content'])
 
     rows = []
-    for row in data['content']:
+    for row in data:
         if region and row['region'] != region:
             continue
         if row['comment'] and not all:


### PR DESCRIPTION
It seems that the fullstop service has changed its default behavior from providing all violations to providing only violations that are not resolved. Therefore the original content filter does not work any longer. Instead it is now necessary to make a second request to the fullstop server to request resolved violations using the query parameter "checked=true".
