### PR TITLE
resolve-violations: continue on error (e.g. access denied)

### DIFF
--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -333,9 +333,9 @@ def resolve_violations(config, comment, since, region, meta, remeta, limit, viol
             continue
         try:
             with Action('Resolving violation {}/{} {} {}..'.format(row['account_id'], row['region'],
-                                                                row['violation_type']['id'], row['id'])):
+                                                                   row['violation_type']['id'], row['id'])):
                 r = session.post(url + '/api/violations/{}/resolution'.format(row['id']), data=comment,
-                                headers={'Authorization': 'Bearer {}'.format(token)})
+                                 headers={'Authorization': 'Bearer {}'.format(token)})
                 r.raise_for_status()
         except:
             # continue, error was printed by Action already

--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -331,11 +331,15 @@ def resolve_violations(config, comment, since, region, meta, remeta, limit, viol
         if row['comment']:
             # already resolved, skip
             continue
-        with Action('Resolving violation {}/{} {} {}..'.format(row['account_id'], row['region'],
-                                                               row['violation_type']['id'], row['id'])):
-            r = session.post(url + '/api/violations/{}/resolution'.format(row['id']), data=comment,
-                             headers={'Authorization': 'Bearer {}'.format(token)})
-            r.raise_for_status()
+        try:
+            with Action('Resolving violation {}/{} {} {}..'.format(row['account_id'], row['region'],
+                                                                row['violation_type']['id'], row['id'])):
+                r = session.post(url + '/api/violations/{}/resolution'.format(row['id']), data=comment,
+                                headers={'Authorization': 'Bearer {}'.format(token)})
+                r.raise_for_status()
+        except:
+            # continue, error was printed by Action already
+            pass
 
 
 def main():


### PR DESCRIPTION
Continue in case of "Forbidden" (no access to account).

This allows me to do:

```bash
$ fullstop resolve -t WRONG_AMI 'Kubernetes cluster running CoreOS' --since 120d --limit 9999
Resolving violation 123869552723/eu-central-1 WRONG_AMI 3814746.. OK
Resolving violation 123214547328/eu-central-1 WRONG_AMI 3848202.. EXCEPTION OCCURRED: 403 Client Error: Forbidden for url: https://fullstop.example.org/api/violations/3848202/resolution
Resolving violation 123214547328/eu-central-1 WRONG_AMI 3848167.. EXCEPTION OCCURRED: 403 Client Error: Forbidden for url: https://fullstop.example.org/api/violations/3848167/resolution
Resolving violation 123214547328/eu-central-1 WRONG_AMI 3848159.. EXCEPTION OCCURRED: 403 Client Error: Forbidden for url: https://fullstop.example.org/api/violations/3848159/resolution
Resolving violation 123214547328/eu-central-1 WRONG_AMI 3848147.. EXCEPTION OCCURRED: 403 Client Error: Forbidden for url: https://fullstop.example.org/api/violations/3848147/resolution
