### PR TITLE
By default do not restrict violations by time

### DIFF
--- a/fullstop/cli.py
+++ b/fullstop/cli.py
@@ -58,7 +58,8 @@ def get_token():
 
 
 def parse_since(s):
-    return normalize_time(s, past=True).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    if s is not None:
+        return normalize_time(s, past=True).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 @cli.command('configure')
@@ -192,7 +193,7 @@ def format_meta_info(meta_info):
 
 accounts_option = click.option('--accounts', metavar='ACCOUNT_IDS',
                                help='AWS account IDs to filter for (default: your configured accounts)')
-since_option = click.option('-s', '--since', default='1d', metavar='TIME_SPEC',
+since_option = click.option('-s', '--since', metavar='TIME_SPEC',
                             help='Only show violations newer than TIME_SPEC (24h, 30d, ..)')
 type_option = click.option('-t', '--type', metavar='VIOLATION_TYPE', help='Only show violations of given type')
 severity_option = click.option('--severity')


### PR DESCRIPTION
This is usability issue that also might be cause of e.g. #18 
This was the problem when I first used this tool and year after I still see other developers confused by this.

Previously default was set to 1 day which is frequent source of confusion since listing might be empty without any indication that filters are applied.

With this change list-violations command defaults to having no "since" filter.

Further improvement in this regard might be to show actual filters that are applied in listing (output of fullstop is not intended for unix-style parsing anyway so I think extra clarifications would be only helpful).
